### PR TITLE
Add nil check after deserializing

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1516,7 +1516,10 @@ minetest.register_tool("fancy_vend:copy_tool",{
         local meta = itemstack:get_meta()
         local node_meta = minetest.get_meta(pos)
         local new_settings = minetest.deserialize(meta:get_string("settings"))
-        if not new_settings then return end
+        if not new_settings then
+        	minetest.chat_send_player(user:get_player_name(), "No settings to set with. Right-click first on the vendor you want to copy settings from.")
+        	return
+        end
 
         if can_modify_vendor(pos, user) then
             -- Admin vendor priv check

--- a/init.lua
+++ b/init.lua
@@ -1516,6 +1516,7 @@ minetest.register_tool("fancy_vend:copy_tool",{
         local meta = itemstack:get_meta()
         local node_meta = minetest.get_meta(pos)
         local new_settings = minetest.deserialize(meta:get_string("settings"))
+        if not new_settings then return end
 
         if can_modify_vendor(pos, user) then
             -- Admin vendor priv check


### PR DESCRIPTION
`minetest.deserialize` can fail and return nil, causing a crash when using the copy wand.