### PR TITLE
Use `mod.conf` instead of `depends.txt` and `description.txt`

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,8 +1,0 @@
-default
-pipeworks?
-digilines?
-awards?
-hopper?
-tell?
-email?
-mail?

--- a/description.txt
+++ b/description.txt
@@ -1,1 +1,0 @@
-A full-featured, fully-integrated vendor mod for Minetest

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,4 @@
 name = fancy_vend
+description = A full-featured, fully-integrated vendor mod for Minetest
+depends = default
+optional_depends = pipeworks, digilines, awards, hopper, tell, email, mail


### PR DESCRIPTION
These files are deprecated and trigger a warning in server logs at startup.